### PR TITLE
Power-on I2C self-test

### DIFF
--- a/software/common/include/i2c/thundervolt.h
+++ b/software/common/include/i2c/thundervolt.h
@@ -70,6 +70,9 @@ enum {
 // Get the hardware revision of Thundervolt
 int thundervolt_get_hardware_revision(uint8_t *hw_rev);
 
+// Check if all regulators are present
+bool thundervolt_regs_present();
+
 // Get the current voltage for the specified rail, in mV
 int thundervolt_get_voltage(uint8_t rail, uint16_t *voltage);
 

--- a/software/common/include/i2c/thundervolt.h
+++ b/software/common/include/i2c/thundervolt.h
@@ -70,8 +70,8 @@ enum {
 // Get the hardware revision of Thundervolt
 int thundervolt_get_hardware_revision(uint8_t *hw_rev);
 
-// Check if all regulators are present
-bool thundervolt_regs_present();
+// Returns true if all regulators and TMP are accessible over i2c. Only usable in i2c controller mode.
+bool thundervolt_i2c_scan();
 
 // Get the current voltage for the specified rail, in mV
 int thundervolt_get_voltage(uint8_t rail, uint16_t *voltage);

--- a/software/common/src/thundervolt.c
+++ b/software/common/src/thundervolt.c
@@ -130,9 +130,12 @@ int thundervolt_get_hardware_revision(uint8_t *hw_rev)
   return 0;
 }
 
-bool thundervolt_regs_present()
+bool thundervolt_i2c_scan()
 {
-  return tps6286x_is_present(THUNDERVOLT_ADDR_HW1_REG_1V0);
+  return tps6286x_is_present(get_regulator_i2c_addr(THUNDERVOLT_RAIL_1V0)) &&
+         tps6286x_is_present(get_regulator_i2c_addr(THUNDERVOLT_RAIL_1V15)) &&
+         tps6286x_is_present(get_regulator_i2c_addr(THUNDERVOLT_RAIL_1V8)) && tps6381x_is_present() &&
+         tmp1075_is_present(THUNDERVOLT_ADDR_TMP);
 }
 
 int thundervolt_get_voltage(uint8_t rail, uint16_t *voltage)

--- a/software/common/src/thundervolt.c
+++ b/software/common/src/thundervolt.c
@@ -130,6 +130,11 @@ int thundervolt_get_hardware_revision(uint8_t *hw_rev)
   return 0;
 }
 
+bool thundervolt_regs_present()
+{
+  return tps6286x_is_present(THUNDERVOLT_ADDR_HW1_REG_1V0);
+}
+
 int thundervolt_get_voltage(uint8_t rail, uint16_t *voltage)
 {
   switch (rail) {

--- a/software/common/src/tps6286x.c
+++ b/software/common/src/tps6286x.c
@@ -63,14 +63,12 @@ static int tps6286x_set_vout(uint8_t addr, uint8_t reg, uint8_t chip_type, uint1
 bool tps6286x_is_present(uint8_t addr)
 {
   // NOTE: The TPS6286X does not have a device ID register
-
   return i2c_detect(addr);
 }
 
 int tps6286x_enable(uint8_t addr, bool enabled)
 {
-  return i2c_reg_update_byte(addr, TPS6286X_REG_CONTROL, TPS6286X_ENABLE,
-                             enabled ? TPS6286X_ENABLE : 0);
+  return i2c_reg_update_byte(addr, TPS6286X_REG_CONTROL, TPS6286X_ENABLE, enabled ? TPS6286X_ENABLE : 0);
 }
 
 int tps6286x_set_slew_rate(uint8_t addr, uint8_t slew_rate)

--- a/software/firmware/platformio.ini
+++ b/software/firmware/platformio.ini
@@ -3,8 +3,9 @@ platform = atmelmegaavr
 board = ATtiny1616
 board_build.f_cpu = 5000000L
 monitor_speed = 115200
+build_unflags = -Os
 build_flags =
-    -Wall -Wextra
+    -Wall -Wextra -O1
 upload_flags = 
     -e
     -v

--- a/software/firmware/src/led.c
+++ b/software/firmware/src/led.c
@@ -179,8 +179,7 @@ void led_effect_update(uint32_t millis)
 
     case EFFECT_BREATHE: {
       uint32_t pos = (elapsed % effect_data.period) * 2;
-      led_set_raw(pos < effect_data.period ? fade_on_brightness(pos)
-                                           : fade_off_brightness(pos - effect_data.period));
+      led_set_raw(pos < effect_data.period ? fade_on_brightness(pos) : fade_off_brightness(pos - effect_data.period));
       break;
     }
 

--- a/software/firmware/src/main.c
+++ b/software/firmware/src/main.c
@@ -288,6 +288,13 @@ int main(void)
   gpio_set_high(EN);
   _delay_ms(10);
 
+  // Make sure we can talk to all four regulators. If not, shut down + enable SOS until power is cycled
+  if (thundervolt_regs_present()) { // pretend detecting a reg = shutdown
+    // Enable the SOS LED effect
+    led_effect_blink_pattern(LED_SOS_PATTERN, sizeof(LED_SOS_PATTERN) / sizeof(LED_SOS_PATTERN[0]));
+    while (1) {};
+  }
+
   // Determine the startup voltages
   uint16_t voltages[4];
   if (in_safe_mode) {


### PR DESCRIPTION
Check presence of all regs + TMP at startup. If any are missing, blink the LED and stall until a reboot. This aids in debugging assembly issues